### PR TITLE
Create task to add group to workspace and pipeline

### DIFF
--- a/PowerBIApiUtils/PowerBIApiUtils.psm1
+++ b/PowerBIApiUtils/PowerBIApiUtils.psm1
@@ -221,6 +221,36 @@ function Add-UserToPipeline {
     }
 }
 
+function Add-GroupToPipeline {
+    param (
+        [Guid] $ActivityId,
+        [string] $Endpoint,
+        [string] $Pipeline,
+        [string] $GroupId
+    )
+
+    try {
+        $foundPipeline = Get-Pipeline -ActivityId $ActivityId -Endpoint $Endpoint -Pipeline $Pipeline
+
+        $url = "pipelines/{0}/users" -f $foundPipeline.Id
+        $body = @{
+            identifier    = $GroupId
+            accessRight   = "Admin"
+            principalType = "Group"
+        } | ConvertTo-Json
+
+        Invoke-PowerBIApi -ActivityId $ActivityId -Endpoint $Endpoint -Url $url -Method Post -Body $body
+
+        Write-Host "Group has been added to pipeline successfully"
+    }
+    catch {
+        $err = Resolve-PowerBIError -Last
+        Write-Error $err.Message
+        
+        throw
+    }
+}
+
 function Add-UserToWorkspace {
     param (
         [Guid] $ActivityId,
@@ -243,6 +273,37 @@ function Add-UserToWorkspace {
         Invoke-PowerBIApi -ActivityId $ActivityId -Endpoint $Endpoint -Url $url -Method Post -Body $body
 
         Write-Host "User has been added to workspace successfully"
+    }
+    catch {
+        $err = Resolve-PowerBIError -Last
+        Write-Error $err.Message
+        
+        throw
+    }
+}
+
+function Add-GroupToWorkspace {
+    param (
+        [Guid] $ActivityId,
+        [string] $Endpoint,
+        [string] $Workspace,
+        [string] $GroupId,
+        [string] $Permission
+    )
+
+    try {
+        $foundWorkspace = Get-Workspace -ActivityId $ActivityId -Endpoint $Endpoint -Workspace $Workspace
+
+        $url = "groups/{0}/users" -f $foundWorkspace.Id
+        $body = @{
+            identifier           = $GroupId
+            groupUserAccessRight = $Permission
+            principalType        = "Group"
+        } | ConvertTo-Json
+
+        Invoke-PowerBIApi -ActivityId $ActivityId -Endpoint $Endpoint -Url $url -Method Post -Body $body
+
+        Write-Host "Group has been added to workspace successfully"
     }
     catch {
         $err = Resolve-PowerBIError -Last
@@ -282,6 +343,7 @@ function Add-WorkspaceToPipeline {
         throw
     }
 }
+
 
 function Remove-WorkspaceFromPipeline {
     param (

--- a/Tasks/Pipelines_AddGroup/run.ps1
+++ b/Tasks/Pipelines_AddGroup/run.ps1
@@ -1,0 +1,7 @@
+$pbiConnection = Get-VstsEndpoint -Name (Get-VstsInput -Name pbiConnection)
+$pipeline = Get-VstsInput -Name pipeline
+$groupId = Get-VstsInput -Name groupId
+
+. .\InitTask.ps1
+
+Add-GroupToPipeline -ActivityId $activityId -Endpoint $endpoint -Pipeline $pipeline -GroupId $groupId

--- a/Tasks/Pipelines_AddGroup/task.json
+++ b/Tasks/Pipelines_AddGroup/task.json
@@ -1,0 +1,50 @@
+{
+    "$schema": "https://raw.githubusercontent.com/Microsoft/azure-pipelines-task-lib/master/tasks.schema.json",
+    "id": "b8d7b861-415f-4624-9b09-1672e5e88992",
+    "name": "DeploymentPipelines-AddGroup",
+    "friendlyName": "Add a user to a deployment pipeline",
+    "description": "Add a user to a Power BI deployment pipeline",
+    "helpMarkDown": "",
+    "category": "Utility",
+    "author": "Microsoft",
+    "version": {
+        "Major": 1,
+        "Minor": 1,
+        "Patch": 0
+    },
+    "demands": [
+        "powershell"
+    ],
+    "instanceNameFormat": "Add a Group to a pipeline",
+    "inputs": [
+        {
+            "name": "pbiConnection",
+            "type": "connectedService:PowerBIService",
+            "label": "Power BI service connection",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": ""
+        },
+        {
+            "name": "pipeline",
+            "type": "string",
+            "label": "Pipeline",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "Enter a pipeline name or ID."
+        },
+        {
+            "name": "groupId",
+            "type": "string",
+            "label": "Group Id",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "Group to be added to the pipeline."
+        }
+    ],
+    "execution": {
+        "PowerShell3": {
+            "target": "Run.ps1"
+        }
+    }
+}

--- a/Tasks/Tests/RunAllTests.ps1
+++ b/Tasks/Tests/RunAllTests.ps1
@@ -19,6 +19,7 @@ With the following template:
     $workspaceId = "***"
     $fileName = "***"
     $userUpn = "***"
+    $groupId = "***"
 #>
 
 If (!(test-path ".\Config\config.ps1")) {

--- a/Tasks/Tests/TestCases/HappyPath.ps1
+++ b/Tasks/Tests/TestCases/HappyPath.ps1
@@ -36,6 +36,15 @@ function TestHappyPath {
         throw "Expected to user $userUpn to be pipeline admin. found=($foundUser)"
     }
 
+    Write-Host "Add group ($groupId) to the pipeline"
+
+    Add-GroupToPipeline -ActivityId $activityId -Endpoint $endpoint -Pipeline $pipeline -GroupId $groupId
+    $users = (Invoke-PowerBIApi -ActivityId $ActivityId -Endpoint $Endpoint -Url "pipelines/$pipelineId/users" -Method Get).value
+    $foundUser = $users | Where-Object { $_.Identifier -eq $groupId }
+    if (!$foundUser -or $foundUser.AccessRight -ne "Admin") {
+        throw "Expected to group $groupId to be pipeline admin. found=($foundUser)"
+    }
+
     Write-Host "Assign workspace ($workspaceName) to development stage"
 
     Add-WorkspaceToPipeline -ActivityId $activityId -Endpoint $endpoint -Pipeline $pipeline -StageOrder 0 -Workspace $workspaceName
@@ -58,6 +67,10 @@ function TestHappyPath {
     Write-Host "Add user ($userUpn) to the test workspace"
 
     Add-UserToWorkspace -ActivityId $activityId -Endpoint $endpoint -Workspace $testWorkspaceName -UserUpn $userUpn -Permission "Admin"
+    
+    Write-Host "Add group ($groupId) to the test workspace"
+    
+    Add-GroupToWorkspace -ActivityId $activityId -Endpoint $endpoint -Workspace $testWorkspaceName -GroupId $groupId -Permission "Admin"
 
     Write-Host "Start selective deployment to the production stage with dataflow, datamart, dataset, report and dashboard named ($fileName)"
 

--- a/Tasks/Workspaces_AddGroup/run.ps1
+++ b/Tasks/Workspaces_AddGroup/run.ps1
@@ -1,0 +1,8 @@
+$pbiConnection = Get-VstsEndpoint -Name (Get-VstsInput -Name pbiConnection)
+$workspace = Get-VstsInput -Name workspace
+$groupId = Get-VstsInput -Name groupId
+$permission = Get-VstsInput -Name permission
+
+. .\InitTask.ps1
+
+Add-GroupToWorkspace -ActivityId $activityId -Endpoint $endpoint -Workspace $workspace -GroupId $groupId -Permission $permission

--- a/Tasks/Workspaces_AddGroup/task.json
+++ b/Tasks/Workspaces_AddGroup/task.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "https://raw.githubusercontent.com/Microsoft/azure-pipelines-task-lib/master/tasks.schema.json",
+    "id": "8e5938ef-e118-40d8-8051-5b8569fe0bf3",
+    "name": "Workspaces-AddGroup",
+    "friendlyName": "Add a group to a workspace",
+    "description": "Add a group to a Power BI workspace",
+    "helpMarkDown": "",
+    "category": "Utility",
+    "author": "Microsoft",
+    "version": {
+        "Major": 1,
+        "Minor": 1,
+        "Patch": 0
+    },
+    "demands": [
+        "powershell"
+    ],
+    "instanceNameFormat": "Add a group to a workspace",
+    "inputs": [
+        {
+            "name": "pbiConnection",
+            "type": "connectedService:PowerBIService",
+            "label": "Power BI service connection",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": ""
+        },
+        {
+            "name": "workspace",
+            "type": "string",
+            "label": "Workspace",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "Enter a workspace name or ID."
+        },
+        {
+            "name": "groupId",
+            "type": "string",
+            "label": "Group Id",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "Group to be added to the workspace."
+        },
+        {
+            "name": "permission",
+            "type": "pickList",
+            "label": "Permission",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "",
+            "options": {
+                "Admin": "Admin",
+                "Member": "Member",
+                "Contributor": "Contributor",
+                "Viewer": "Viewer"
+            }
+        }
+    ],
+    "execution": {
+        "PowerShell3": {
+            "target": "Run.ps1"
+        }
+    }
+}

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "pbi-automation-tools-dev",
     "publisher": "ms-pbi-api",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "name": "Power BI automation tools",
     "description": "Automate release management tasks related to Power BI deployment pipelines",
     "public": false,
@@ -121,6 +121,16 @@
             }
         },
         {
+            "id": "Pipelines_AddGroup",
+            "type": "ms.vss-distributed-task.task",
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
+            "properties": {
+                "name": "Tasks/Pipelines_AddGroup"
+            }
+        },
+        {
             "id": "Workspaces_AddUser",
             "type": "ms.vss-distributed-task.task",
             "targets": [
@@ -128,6 +138,16 @@
             ],
             "properties": {
                 "name": "Tasks/Workspaces_AddUser"
+            }
+        },
+        {
+            "id": "Workspaces_AddGroup",
+            "type": "ms.vss-distributed-task.task",
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
+            "properties": {
+                "name": "Tasks/Workspaces_AddGroup"
             }
         },
         {


### PR DESCRIPTION
Implement tasks for Add-GroupToWorkspace and Add-GroupToPipeline. Duplicated code from Add-UserToWorkspace and Add-GrouToPipeline  ensure backwards compatibility, preventing a breaking change.

Fixes: https://github.com/microsoft/powerbi-azure-pipelines-extensions/issues/29